### PR TITLE
Add kubernetes basics

### DIFF
--- a/client/csharp/ExchangeOGramClient/Dockerfile
+++ b/client/csharp/ExchangeOGramClient/Dockerfile
@@ -1,0 +1,12 @@
+FROM microsoft/dotnet:latest
+
+COPY . /app/
+
+WORKDIR /app
+RUN dotnet restore
+RUN dotnet publish
+
+ENV ASPNETCORE_URLS http://0.0.0.0:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "exec", "/app/bin/Debug/netcoreapp1.1/publish/ExchangeOGramClient.dll"]
+

--- a/client/csharp/ExchangeOGramClient/Startup.cs
+++ b/client/csharp/ExchangeOGramClient/Startup.cs
@@ -40,15 +40,10 @@ namespace ExchangeOGram
             loggerFactory.AddConsole(Configuration.GetSection("Logging"));
             loggerFactory.AddDebug();
 
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-                app.UseBrowserLink();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Home/Error");
-            }
+            // WARNING: Normally, we should only expose exceptions
+            // while in dev mode, but for demo purposes this is fine.
+            app.UseDeveloperExceptionPage();
+            app.UseBrowserLink();
 
             app.UseStaticFiles();
 

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,19 @@
+##Install kubectl
+```
+gcloud components install kubectl
+```
+
+For instructions how to setup kubectl with GKE cluster, see
+https://cloud.google.com/container-engine/docs/clusters/operations
+
+##Deploying C# frontend
+```
+kubectl create -f frontend-all.yaml
+```
+
+##Deploying Java backend
+```
+kubectl create -f backend-all.yaml
+```
+
+

--- a/kubernetes/backend-all.yaml
+++ b/kubernetes/backend-all.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app: exchangeogram
+    tier: backend
+spec:
+  ports:
+  - port: 8081
+  selector:
+    app: exchangeogram
+    tier: backend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: exchangeogram
+        tier: backend
+    spec:
+      containers:
+      - name: backend
+        image: gcr.io/grpc-kubecon-demo2017/javabackend:test1
+        ports:
+        - containerPort: 8081

--- a/kubernetes/frontend-all.yaml
+++ b/kubernetes/frontend-all.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: exchangeogram
+    tier: frontend
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8080
+  selector:
+    app: exchangeogram
+    tier: frontend
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: exchangeogram
+        tier: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: gcr.io/grpc-kubecon-demo2017/csharpfrontend:test4
+        ports:
+        - containerPort: 8080

--- a/server/java/Dockerfile
+++ b/server/java/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:8
+
+COPY . /app/
+
+WORKDIR /app
+
+RUN ./gradlew :installDist
+
+ENV GOOGLE_CLOUD_PROJECT grpc-kubecon-demo2017
+
+ENTRYPOINT /app/build/install/demo/bin/demo


### PR DESCRIPTION
With these changes, one can deploy C# frontend to GKE and make it publicly visible. The Java backend is also deployable to kubernetes, but the C# frontend does not connect to it yet.
Also, more setting might be necessary to enable Spanner access from GKE cluster.